### PR TITLE
Initial setup fix and tweaks

### DIFF
--- a/BlazorShop.Infrastructure/Persistence/ApplicationDbContextSeed.cs
+++ b/BlazorShop.Infrastructure/Persistence/ApplicationDbContextSeed.cs
@@ -60,12 +60,14 @@ namespace BlazorShop.Infrastructure.Persistence
         {
             var admin = new User
             {
-                UserName = seedData.FirstName + "@" + seedData.LastName,
+                UserName = seedData.Username,
                 Email = seedData.Email,
                 FirstName = seedData.FirstName,
                 LastName = seedData.LastName,
                 IsActive = true,
+                SecurityStamp = Guid.NewGuid().ToString(),
             };
+
             var adminRole = roleManager.Roles.Where(x => x.Name == seedData.RoleName).FirstOrDefault();
             if (adminRole == null)
             {
@@ -74,7 +76,14 @@ namespace BlazorShop.Infrastructure.Persistence
 
             if (userManager.Users.All(u => u.Email != admin.Email))
             {
-                await userManager.CreateAsync(admin, seedData.Password);
+                var result = await userManager.CreateAsync(admin, seedData.Password);
+
+                if (result.Errors.Any())
+                {
+                    // likely password requirement errors
+                    throw new Exception("Errors creating admin: " + string.Join(",", result.Errors.Select(x => x.Description)));
+                }
+
                 await userManager.AddToRoleAsync(admin, adminRole.Name);
             }
         }
@@ -92,7 +101,8 @@ namespace BlazorShop.Infrastructure.Persistence
                 {
                     Name = "Jeans 1",
                     Description = "asdsad sdasd sad asd dsa",
-                    Price = new decimal(344.00), Amount = 12,
+                    Price = new decimal(344.00),
+                    Amount = 12,
                     ImageName = "buy-3",
                     ImagePath = "buy-3.jpg",
                     IsActive = true,

--- a/BlazorShop.Infrastructure/Utils/AdminSeedModel.cs
+++ b/BlazorShop.Infrastructure/Utils/AdminSeedModel.cs
@@ -10,6 +10,11 @@ namespace BlazorShop.Infrastructure.Utils
     public class AdminSeedModel
     {
         /// <summary>
+        /// Gets or Sets the username.
+        /// </summary>
+        public string? Username { get; set; }
+
+        /// <summary>
         /// Gets or Sets the firstname.
         /// </summary>
         public string? FirstName { get; set; }

--- a/BlazorShop.WebApi/Program.cs
+++ b/BlazorShop.WebApi/Program.cs
@@ -37,10 +37,10 @@ try
 
     // Add JWT TOKEN Settings
     builder.Services.AddAuthentication(opt =>
-        {
-            opt.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-            opt.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-        })
+    {
+        opt.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        opt.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
         .AddJwtBearer(options =>
         {
             options.Audience = builder.Configuration["JwtToken:Audience"];
@@ -97,6 +97,7 @@ try
             };
             var adminSeed = new AdminSeedModel
             {
+                Username = builder.Configuration["AdminSeedModel:Username"],
                 FirstName = builder.Configuration["AdminSeedModel:FirstName"],
                 LastName = builder.Configuration["AdminSeedModel:LastName"],
                 Email = builder.Configuration["AdminSeedModel:Email"],
@@ -148,7 +149,7 @@ try
         context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
         context.Response.Headers.Add("Referrer-Policy", "same-origin");
         context.Response.Headers.Add("Permissions-Policy", "geolocation=(), camera=()");
-        #pragma warning disable SA1118 // Parameter should not span multiple lines
+#pragma warning disable SA1118 // Parameter should not span multiple lines
         context.Response.Headers.Add(builder.Configuration["ContentPolicy"], "default-src "
             + "self  "
             + "https://maxcdn.bootstrapcdn.com  "
@@ -156,7 +157,7 @@ try
             + "https://sshmantest.azurewebsites.net "
             + "https://code.jquery.com https://dc.services.visualstudio.com "
             + " 'unsafe-inline' 'unsafe-eval'");
-        #pragma warning restore SA1118 // Parameter should not span multiple lines
+#pragma warning restore SA1118 // Parameter should not span multiple lines
         context.Response.Headers.Add("SameSite", "Strict");
         context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
         await next();

--- a/BlazorShop.WebApi/appsettings.json
+++ b/BlazorShop.WebApi/appsettings.json
@@ -31,20 +31,21 @@
 	"AllowedHosts": "*"
 
 	//"RolesSeedModel": {
-	//	"AdminRoleName": "",
-	//	"AdmintRoleNormalizedName": "",
-	//	"UserRoleName": "",
-	//	"UserRoleNormalizedName": "",
-	//	"DefaultRoleName": "",
-	//	"DefaultRoleNormalizedName": ""
+	//  "AdminRoleName": "",
+	//  "AdminRoleNormalizedName": "",
+	//  "UserRoleName": "",
+	//  "UserRoleNormalizedName": "",
+	//  "DefaultRoleName": "",
+	//  "DefaultRoleNormalizedName": ""
 	//},
 	//"AdminSeedModel": {
-	//	"FirstName": "",
-	//	"LastName": "",
-	//	"Email": "",
-	//	"Password": "",
-	//	"RoleName": ""
-	//},
+	//  "Username": "",
+	//  "FirstName": "",
+	//  "LastName": "",
+	//  "Email": "",
+	//  "Password": "", // caps, numeric and symbol required
+	//  "RoleName": "" // use admin role set above
+	//}
 	//"BusinessEmail": {
 	//	"Host": "smtp.gmail.com",
 	//	"Port": 587,

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 * <strike>Video Demo Link: (In the Future)</strike>
 * <strike>Unit of Work Project to demonstrate the Unit of Work with Repository Pattern design pattern</strike>
 
+# Setup Project
+
+* Run 'update-database' command to setup migrations.
+* Uncomment and update the seed fields in appsettings.json.
+* Run application to apply seeding.
+* Empty the seed fields from appsettings.json and comment again.
+
 # Web API functionalities
 	* Worker Service Project - to deactivate a user subscription
 	* Unit Test Project (Under Development)


### PR DESCRIPTION
Username with '@' not allowed triggering error when creating an admin, added username field  instead.
Lack of security stamp triggering error when creating an admin.
No feedback when admin user is not created because of password validation, added exception to fail earlier.
Fix typo on seeding text for admin (admint).
Add initial steps to 'read me' to help people on their first steps.